### PR TITLE
Include support for magic calls.

### DIFF
--- a/src/HasRoles.php
+++ b/src/HasRoles.php
@@ -9,9 +9,9 @@ use Ajimoti\RolesAndPermissions\Helpers\BasePermission;
 use Ajimoti\RolesAndPermissions\Models\ModelRole;
 use Ajimoti\RolesAndPermissions\Repositories\BelongsToManyRepository;
 use Ajimoti\RolesAndPermissions\Repositories\ModelRepository;
-use Illuminate\Database\Eloquent\Model;
 use Ajimoti\RolesAndPermissions\Traits\HasDirectPermissions;
 use Ajimoti\RolesAndPermissions\Traits\SupportsMagicCalls;
+use Illuminate\Database\Eloquent\Model;
 
 trait HasRoles
 {
@@ -213,7 +213,8 @@ trait HasRoles
     {
         if ($this->isPossibleMagicCall($method)) {
             return $this->performMagic(
-                $method, $this->repository()->getRoleEnumClass()
+                $method,
+                $this->repository()->getRoleEnumClass()
             );
         }
 

--- a/src/HasRoles.php
+++ b/src/HasRoles.php
@@ -10,10 +10,13 @@ use Ajimoti\RolesAndPermissions\Models\ModelRole;
 use Ajimoti\RolesAndPermissions\Repositories\BelongsToManyRepository;
 use Ajimoti\RolesAndPermissions\Repositories\ModelRepository;
 use Illuminate\Database\Eloquent\Model;
+use Ajimoti\RolesAndPermissions\Traits\HasDirectPermissions;
+use Ajimoti\RolesAndPermissions\Traits\SupportsMagicCalls;
 
 trait HasRoles
 {
     use HasDirectPermissions;
+    use SupportsMagicCalls;
 
     /**
      * Change the repository used to the pivot table repository
@@ -204,5 +207,16 @@ trait HasRoles
     public function repository(): ModelRepository
     {
         return new ModelRepository($this);
+    }
+
+    public function __call($method, $parameters)
+    {
+        if ($this->isPossibleMagicCall($method)) {
+            return $this->performMagic(
+                $method, $this->repository()->getRoleEnumClass()
+            );
+        }
+
+        return parent::__call($method, $parameters);
     }
 }

--- a/src/Repositories/BelongsToManyRepository.php
+++ b/src/Repositories/BelongsToManyRepository.php
@@ -15,10 +15,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Ajimoti\RolesAndPermissions\Traits\SupportsMagicCalls;
 
 class BelongsToManyRepository implements RolesContract, PivotContract
 {
     use Authorizable;
+    use SupportsMagicCalls;
 
     /**
      * Methods used to filter results when defining a 'belongsToMany' relationship
@@ -205,6 +207,7 @@ class BelongsToManyRepository implements RolesContract, PivotContract
             return $query->detach();
         }
 
+        // If the role enum class isn't set to delete pivot records, we'll just set the role column to null.
         return $query->updateExistingPivot($this->relatedModel->id, [$this->roleColumnName => null]);
     }
 
@@ -246,6 +249,12 @@ class BelongsToManyRepository implements RolesContract, PivotContract
             $this->pivot->appendCondition($method, $parameters);
 
             return $this;
+        }
+
+        if ($this->isPossibleMagicCall($method)) {
+            return $this->performMagic(
+                $method, $this->pivot->getRoleEnumClass()
+            );
         }
 
         throw new BadMethodCallException(sprintf(

--- a/src/Repositories/BelongsToManyRepository.php
+++ b/src/Repositories/BelongsToManyRepository.php
@@ -10,12 +10,12 @@ use Ajimoti\RolesAndPermissions\Contracts\RolesContract;
 use Ajimoti\RolesAndPermissions\Facades\Check;
 use Ajimoti\RolesAndPermissions\Helpers\BasePermission;
 use Ajimoti\RolesAndPermissions\Helpers\Pivot;
+use Ajimoti\RolesAndPermissions\Traits\SupportsMagicCalls;
 use BadMethodCallException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Ajimoti\RolesAndPermissions\Traits\SupportsMagicCalls;
 
 class BelongsToManyRepository implements RolesContract, PivotContract
 {
@@ -253,7 +253,8 @@ class BelongsToManyRepository implements RolesContract, PivotContract
 
         if ($this->isPossibleMagicCall($method)) {
             return $this->performMagic(
-                $method, $this->pivot->getRoleEnumClass()
+                $method,
+                $this->pivot->getRoleEnumClass()
             );
         }
 

--- a/src/Repositories/ModelRepository.php
+++ b/src/Repositories/ModelRepository.php
@@ -265,7 +265,7 @@ class ModelRepository implements RolesContract, DirectPermissionsContract
      *
      * @return string
      */
-    private function getRoleEnumClass(): string
+    public function getRoleEnumClass(): string
     {
         $tableName = $this->model->getTable();
 

--- a/src/Traits/HasDirectPermissions.php
+++ b/src/Traits/HasDirectPermissions.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ajimoti\RolesAndPermissions;
+namespace Ajimoti\RolesAndPermissions\Traits;
 
 use Ajimoti\RolesAndPermissions\Collections\PermissionCollection;
 use Ajimoti\RolesAndPermissions\Models\ModelPermission;

--- a/src/Traits/SupportsMagicCalls.php
+++ b/src/Traits/SupportsMagicCalls.php
@@ -3,7 +3,6 @@
 namespace Ajimoti\RolesAndPermissions\Traits;
 
 use Illuminate\Support\Str;
-use Ajimoti\RolesAndPermissions\Contracts\RolesContract;
 
 trait SupportsMagicCalls
 {
@@ -43,8 +42,8 @@ trait SupportsMagicCalls
             // When the user uses the magic method is[Role]()
             // to check if the model has the role.
             $role = substr($method, 2);
-            return $this->hasRole(constant("{$enumClass}::{$role}"));
 
+            return $this->hasRole(constant("{$enumClass}::{$role}"));
         } elseif (Str::startsWith($method, 'can') && Str::length($method) > 3) {
             // When the user uses the magic method can[Permission]()
             // to check if the model has the permission.

--- a/src/Traits/SupportsMagicCalls.php
+++ b/src/Traits/SupportsMagicCalls.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Ajimoti\RolesAndPermissions\Traits;
+
+use Illuminate\Support\Str;
+use Ajimoti\RolesAndPermissions\Contracts\RolesContract;
+
+trait SupportsMagicCalls
+{
+    /**
+     * Method to call on the model to check if the model has the role.
+     *
+     * @return bool
+     */
+    abstract public function hasRole(): bool;
+
+    /**
+     * Method to call on the model to check if the model holds the permissions.
+     *
+     * @return bool
+     */
+    abstract public function holds(): bool;
+
+    /**
+     * Checks if the magic method called is to validate a role or a permission
+     *
+     * @param  string  $method
+     * @return bool
+     */
+    private function isPossibleMagicCall($method): bool
+    {
+        // When the user uses the magic method is[Role]()
+        // to check if the model has the role.
+        // OR when the user uses the magic method can[Permission]()
+        // to check if the model has the permission.
+        return (Str::startsWith($method, 'is') && Str::length($method) > 2) ||
+                (Str::startsWith($method, 'can') && Str::length($method) > 3);
+    }
+
+    public function performMagic($method, $enumClass)
+    {
+        if (Str::startsWith($method, 'is') && Str::length($method) > 2) {
+            // When the user uses the magic method is[Role]()
+            // to check if the model has the role.
+            $role = substr($method, 2);
+            return $this->hasRole(constant("{$enumClass}::{$role}"));
+
+        } elseif (Str::startsWith($method, 'can') && Str::length($method) > 3) {
+            // When the user uses the magic method can[Permission]()
+            // to check if the model has the permission.
+            $permission = substr($method, 3);
+            $permissionClass = $enumClass::$permissionClass;
+
+            return $this->holds(constant("{$permissionClass}::{$permission}"));
+        }
+    }
+}

--- a/tests/Feature/MagicMethodsTest.php
+++ b/tests/Feature/MagicMethodsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Ajimoti\RolesAndPermissions\Tests\Enums\MerchantRole;
+use Ajimoti\RolesAndPermissions\Tests\Models\Merchant;
+use Ajimoti\RolesAndPermissions\Tests\Models\User;
+
+beforeEach(function () {
+    config()->set('roles-and-permissions.roles_enum.merchant_user', MerchantRole::class);
+
+    $this->model = Merchant::factory()->create();
+    $this->user = User::factory()->create();
+    $this->role = MerchantRole::getRandomValue();
+    $this->roleInstance = MerchantRole::fromValue($this->role);
+
+    $this->user->of($this->model)->assign($this->role);
+    $this->model->assign($this->role);
+});
+
+it('can check that a model has a role using magic method', function () {
+    expect($this->model->hasRole($this->role))->toBeTrue();
+
+    expect($this->model->{"is".$this->roleInstance->key}())->toBeTrue();
+})->group('MagicMethods');
+
+it('can check that a model has a permission using magic method', function () {
+    expect($this->model->hasRole($this->role))->toBeTrue();
+
+    foreach ($this->roleInstance->permissions as $permission) {
+        expect($this->model->{"can".$permission->key}())->toBeTrue();
+    }
+})->group('MagicMethods');
+
+it('can check that a many-to-many relationship has a role using magic method', function () {
+    expect($this->user->of($this->model)->hasRole($this->role))->toBeTrue();
+
+    expect($this->user->of($this->model)->{"is".$this->roleInstance->key}())->toBeTrue();
+})->group('MagicMethods');
+
+it('can check that a many-to-many relationship has a permission using magic method', function () {
+    expect($this->user->of($this->model)->hasRole($this->role))->toBeTrue();
+
+    foreach ($this->roleInstance->permissions as $permission) {
+        expect($this->user->of($this->model)->{"can".$permission->key}())->toBeTrue();
+    }
+})->group('MagicMethods');
+
+it('magic method functionality does not interfere with laravel `is()` method', function () {
+    expect($this->user->is(User::factory()->create()))->toBeFalse();
+
+    expect($this->user->is($this->user))->toBeTrue();
+})->group('MagicMethods');
+
+it('magic method functionality does not interfere with laravel `can()` method', function () {
+    expect($this->model->can("a_random_permission_ha_ha_ha"))->toBeFalse();
+
+    // Cases where MerchantRole::Customer is the assigned role,
+    // the permissions list will be empty
+    if ($this->roleInstance->permissions->isNotEmpty()) {
+        $permission = $this->roleInstance->permissions->random();
+
+        expect($this->model->can($permission->value))->toBeTrue();
+    }
+})->group('MagicMethods');


### PR DESCRIPTION
This PR includes support for magic calls.

**For example:** 
After a model has been assigned a role, we shouldn't have to always use the `->hasRole()` method to check if the user has a specific role. Developers should be able to prepend `is` with the role key and make a call on the model like so:

```php
// $model->is{role_key}()
$model->isSuperAdmin() // returns bool
```

Similarly, perpend `can` with the permission to check if the model has a permission:
```php
// $model->can{permission_key}()
$model->canDeleteTransactions(); // returns bool
```
